### PR TITLE
Use Cart rather than the model

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -4,8 +4,8 @@ namespace Igniter\Coupons;
 
 use Admin\Models\Customers_model;
 use Admin\Models\Orders_model;
+use Cart;
 use Igniter\Cart\Classes\CartManager;
-use Igniter\Cart\Models\Cart;
 use Igniter\Coupons\Models\Coupons_history_model;
 use Igniter\Coupons\Models\Coupons_model;
 use Illuminate\Database\Eloquent\Relations\Relation;


### PR DESCRIPTION
The call to Cart::conditions() fails in admin.order.paymentProcessed without this.

Unless I'm misunderstanding - this shouldn't be referencing the model as it doesnt provide a conditions() method