### PR TITLE
prevent coupon to be applied if expired

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -10,8 +10,8 @@ use Igniter\Coupons\Models\Coupons_history_model;
 use Igniter\Coupons\Models\Coupons_model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\Event;
-use System\Classes\BaseExtension;
 use Location;
+use System\Classes\BaseExtension;
 
 class Extension extends BaseExtension
 {
@@ -27,9 +27,9 @@ class Extension extends BaseExtension
             Coupons_model::isEnabled()->isAutoApplicable()
                 ->each(function ($coupon) {
                     $orderDateTime = Location::orderDateTime();
-                    if($coupon->isExpired($orderDateTime)) 
+                    if($coupon->isExpired($orderDateTime))
                         return;
-                    
+
                     $cartManager = CartManager::instance();
                     $cartManager->applyCouponCondition($coupon->code);
                 });

--- a/Extension.php
+++ b/Extension.php
@@ -11,6 +11,7 @@ use Igniter\Coupons\Models\Coupons_model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\Event;
 use System\Classes\BaseExtension;
+use Location;
 
 class Extension extends BaseExtension
 {
@@ -22,8 +23,13 @@ class Extension extends BaseExtension
         });
 
         Event::listen('cart.added', function ($order) {
+
             Coupons_model::isEnabled()->isAutoApplicable()
                 ->each(function ($coupon) {
+                    $orderDateTime = Location::orderDateTime();
+                    if($coupon->isExpired($orderDateTime)) 
+                        return;
+                    
                     $cartManager = CartManager::instance();
                     $cartManager->applyCouponCondition($coupon->code);
                 });

--- a/Extension.php
+++ b/Extension.php
@@ -8,6 +8,7 @@ use Cart;
 use Igniter\Cart\Classes\CartManager;
 use Igniter\Coupons\Models\Coupons_history_model;
 use Igniter\Coupons\Models\Coupons_model;
+use Igniter\Local\Facades\Location;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\Event;
 use System\Classes\BaseExtension;
@@ -22,9 +23,12 @@ class Extension extends BaseExtension
         });
 
         Event::listen('cart.added', function ($order) {
-
             Coupons_model::isEnabled()->isAutoApplicable()
                 ->each(function ($coupon) {
+                    $orderDateTime = Location::orderDateTime();
+                    if ($coupon->isExpired($orderDateTime))
+                        return;
+
                     $cartManager = CartManager::instance();
                     $cartManager->applyCouponCondition($coupon->code);
                 });

--- a/Extension.php
+++ b/Extension.php
@@ -10,7 +10,6 @@ use Igniter\Coupons\Models\Coupons_history_model;
 use Igniter\Coupons\Models\Coupons_model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\Event;
-use Location;
 use System\Classes\BaseExtension;
 
 class Extension extends BaseExtension
@@ -26,10 +25,6 @@ class Extension extends BaseExtension
 
             Coupons_model::isEnabled()->isAutoApplicable()
                 ->each(function ($coupon) {
-                    $orderDateTime = Location::orderDateTime();
-                    if($coupon->isExpired($orderDateTime))
-                        return;
-
                     $cartManager = CartManager::instance();
                     $cartManager->applyCouponCondition($coupon->code);
                 });

--- a/cartconditions/Coupon.php
+++ b/cartconditions/Coupon.php
@@ -79,7 +79,6 @@ class Coupon extends CartCondition
             $this->getApplicableItems($couponModel);
         }
         catch (Exception $ex) {
-
             if (!optional($couponModel)->auto_apply)
                 flash()->alert($ex->getMessage())->now();
 
@@ -92,18 +91,6 @@ class Coupon extends CartCondition
         $couponModel = $this->getModel();
         if (!$couponModel OR $couponModel->is_limited_to_cart_item)
             return FALSE;
-
-        try {
-
-            $this->validateCoupon($couponModel);
-
-        } catch (Exception $ex) {
-
-            $this->removeMetaData('code');
-
-            return FALSE;
-        }
-
     }
 
     public function getActions()
@@ -111,7 +98,7 @@ class Coupon extends CartCondition
         $value = optional($this->getModel())->discountWithOperand();
 
         // if we are item limited and not a % we need to apportion
-        if (stripos($value, '%') === false AND optional($this->getModel())->is_limited_to_cart_item) {
+        if (stripos($value, '%') === FALSE AND optional($this->getModel())->is_limited_to_cart_item) {
             $value = $this->calculateApportionment($value);
         }
 

--- a/cartconditions/Coupon.php
+++ b/cartconditions/Coupon.php
@@ -79,6 +79,7 @@ class Coupon extends CartCondition
             $this->getApplicableItems($couponModel);
         }
         catch (Exception $ex) {
+
             if (!optional($couponModel)->auto_apply)
                 flash()->alert($ex->getMessage())->now();
 
@@ -91,6 +92,17 @@ class Coupon extends CartCondition
         $couponModel = $this->getModel();
         if (!$couponModel OR $couponModel->is_limited_to_cart_item)
             return FALSE;
+         
+        try {
+   
+            $this->validateCoupon($couponModel);
+            
+        } catch (Exception $ex) {
+ 
+            $this->removeMetaData('code');
+            return FALSE;
+        }
+
     }
 
     public function getActions()

--- a/cartconditions/Coupon.php
+++ b/cartconditions/Coupon.php
@@ -92,13 +92,13 @@ class Coupon extends CartCondition
         $couponModel = $this->getModel();
         if (!$couponModel OR $couponModel->is_limited_to_cart_item)
             return FALSE;
-         
+
         try {
-   
+
             $this->validateCoupon($couponModel);
-            
+
         } catch (Exception $ex) {
- 
+
             $this->removeMetaData('code');
             return FALSE;
         }

--- a/cartconditions/Coupon.php
+++ b/cartconditions/Coupon.php
@@ -100,6 +100,7 @@ class Coupon extends CartCondition
         } catch (Exception $ex) {
 
             $this->removeMetaData('code');
+
             return FALSE;
         }
 


### PR DESCRIPTION
Prevent a coupon from being applied even if it has already expired, or if the card date time is not aligned with the expeted day and time of its order.

relates #18