### PR TITLE
Remove coupon code length limit on database.

### DIFF
--- a/database/migrations/2021_02_22_000300_increase_coupon_code_character_limit.php
+++ b/database/migrations/2021_02_22_000300_increase_coupon_code_character_limit.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class ExtendCouponCodeLength extends Migration
+class IncreaseCouponCodeCharacterLimit extends Migration
 {
     public function up()
     {

--- a/database/migrations/2021_02_22_000300_remove_coupon_length_limit.php
+++ b/database/migrations/2021_02_22_000300_remove_coupon_length_limit.php
@@ -10,6 +10,8 @@ class ExtendCouponCodeLength extends Migration
 {
     public function up()
     {
-        $table->string('code')->unique('code')->change();
+        Schema::table('igniter_coupons', function (Blueprint $table) {
+            $table->string('code')->unique()->change();
+        });
     }
 }

--- a/database/migrations/2021_02_22_000300_remove_coupon_length_limit.php
+++ b/database/migrations/2021_02_22_000300_remove_coupon_length_limit.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Igniter\Coupons\Database\Migrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ExtendCouponCodeLength extends Migration
+{
+    public function up()
+    {
+        $table->string('code')->unique('code')->change();
+    }
+}


### PR DESCRIPTION
Removes the length limit of 15 characters on the coupon code from the database. Closes #23 

@sampoyigi please validate I've got this right... first time doing a DB migration!